### PR TITLE
Fix ATR% calculation

### DIFF
--- a/src/calculator.py
+++ b/src/calculator.py
@@ -536,7 +536,7 @@ class OptionsAnalyzer:
                     atr14 = 0
                 else:
                     atr14 = self.compute_atr(hist_atr, window=14)
-                atr14_pct = (atr14/up) if up else 0
+                atr14_pct = (atr14/up) * 100 if up else 0
                 return {
                     'avg_volume': avgv >= 1_500_000,
                     'avg_volume_value': avgv,


### PR DESCRIPTION
The column ATR% is calculated in the code like this:

atr14_pct = (atr14/up) if up else 0

If I take a recent example for GME, ATR% shows up in the table as 0.04% But if I take ATR / underlying price (1.18 / 29.23), that equals 0.040369483 To be clear, 0.040369483 equals 4.037% (rounded)

So, the data in the ATR% column is being misstated.